### PR TITLE
Version 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The app is organized as a desktop split-view and a mobile-friendly single-column
 
 - Left pane: identity, summary, availability state, quick contact actions, tech stack, and social icons
 - Right pane: sticky section navigation, projects, certificates, journey, and social links
-- Navigation: smooth in-page scrolling with a dedicated external `Resume` button
+- Navigation: smooth in-page scrolling across portfolio sections
+- Availability: direct contact actions with the external `Resume` button placed in the `Currently looking` area
 - Content: local typed source files under `src/content`
 
 The current availability state is controlled in code and can render either:
@@ -30,8 +31,9 @@ The current availability state is controlled in code and can render either:
 - Responsive mobile layout with wrapped navigation and stacked action controls
 - Typed portfolio content for projects, certificates, journey, profile, socials, and tech stack
 - Smooth section scrolling from the right-pane navigation
-- Resume link exposed as a dedicated external nav action
+- Resume link exposed in the availability action group
 - Availability panel with content-driven action buttons
+- Floating scroll-to-top button that appears after scrolling
 
 ## Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/manrope": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfolio",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/certificates-section.tsx
+++ b/src/components/certificates-section.tsx
@@ -7,7 +7,7 @@ export function CertificatesSection() {
       id="certificates"
       eyebrow="Verified Developer Credentials"
       title="Certificates"
-      description="A collection of official certificates that validate my training, completed coursework, and commitment to building a strong foundation as a developer."
+      description="A collection of official certificates that validate my training, completed coursework, and commitment to building a strong foundation as a developer. View each certificate directly from this section."
     >
       <div className="divide-y divide-white/10">
         {CERTIFICATES.map((certificate, index) => (

--- a/src/components/portfolio-nav.tsx
+++ b/src/components/portfolio-nav.tsx
@@ -1,6 +1,5 @@
 import type { MouseEvent } from 'react'
 
-import { RESUME_LINK } from '@/content/navigation'
 import type { NavItem } from '@/content/types'
 
 export function PortfolioNav({ items }: { items: NavItem[] }) {
@@ -34,18 +33,6 @@ export function PortfolioNav({ items }: { items: NavItem[] }) {
             </li>
           )
         })}
-
-        <li>
-          <a
-            href={RESUME_LINK.href}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex min-h-10 w-full items-center justify-center gap-2 border border-sky-300/25 bg-sky-300/10 px-3 py-2 text-sm text-sky-50 transition duration-200 hover:border-sky-200/40 hover:bg-sky-300/16 focus-visible:ring-2 focus-visible:ring-sky-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 sm:w-auto sm:justify-start"
-          >
-            <RESUME_LINK.icon className="size-4 text-sky-100" aria-hidden="true" />
-            {RESUME_LINK.label}
-          </a>
-        </li>
       </ul>
     </nav>
   )

--- a/src/components/portfolio-page.tsx
+++ b/src/components/portfolio-page.tsx
@@ -1,12 +1,17 @@
+import { useRef } from 'react'
+
 import { CertificatesSection } from '@/components/certificates-section'
 import { JourneySection } from '@/components/journey-section'
 import { PortfolioNav } from '@/components/portfolio-nav'
 import { ProfilePanel } from '@/components/profile-panel'
 import { ProjectsSection } from '@/components/projects-section'
+import { ScrollToTopButton } from '@/components/scroll-to-top-button'
 import { SocialSection } from '@/components/social-section'
 import { NAV_ITEMS } from '@/content/navigation'
 
 export function PortfolioPage() {
+  const contentRef = useRef<HTMLElement | null>(null)
+
   return (
     <div className="relative min-h-dvh overflow-x-clip bg-background text-foreground">
       <div
@@ -23,7 +28,10 @@ export function PortfolioPage() {
               <PortfolioNav items={NAV_ITEMS} />
             </div>
 
-            <main className="divide-y divide-white/10 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+            <main
+              ref={contentRef}
+              className="divide-y divide-white/10 lg:min-h-0 lg:flex-1 lg:overflow-y-auto"
+            >
               <ProjectsSection />
               <CertificatesSection />
               <JourneySection />
@@ -32,6 +40,8 @@ export function PortfolioPage() {
           </div>
         </div>
       </div>
+
+      <ScrollToTopButton scrollContainerRef={contentRef} />
     </div>
   )
 }

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -1,8 +1,11 @@
+import { RESUME_LINK } from '@/content/navigation'
 import { PROFILE } from '@/content/profile'
 import { SOCIAL_LINKS } from '@/content/socials'
 import { TECH_STACK } from '@/content/tech-stack'
 
 export function ProfilePanel() {
+  const availabilityActions = [RESUME_LINK, ...PROFILE.availability.actions]
+
   return (
     <aside className="py-4 md:py-0 lg:sticky lg:top-0 lg:self-start">
       <div className="flex w-full flex-col gap-6 px-1 md:gap-7 lg:max-h-[calc(100dvh-4rem)] lg:pr-6">
@@ -40,8 +43,12 @@ export function ProfilePanel() {
           </div>
 
           {PROFILE.availability.isOpenToWork ? (
-            <div className="grid gap-2 sm:grid-cols-2">
-              {PROFILE.availability.actions.map((action) => {
+            <div
+              role="group"
+              aria-label="Currently looking actions"
+              className="grid gap-2 sm:grid-cols-2"
+            >
+              {availabilityActions.map((action) => {
                 const Icon = action.icon
                 const isDisabled = action.href.length === 0
                 const isExternal = action.href.length > 0 && !action.href.startsWith('mailto:')

--- a/src/components/scroll-to-top-button.tsx
+++ b/src/components/scroll-to-top-button.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState, type RefObject } from 'react'
+import { ArrowUp } from 'lucide-react'
+
+const VISIBILITY_THRESHOLD = 160
+
+function getScrollBehavior(): ScrollBehavior {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ? 'auto' : 'smooth'
+}
+
+type ScrollToTopButtonProps = {
+  scrollContainerRef: RefObject<HTMLElement | null>
+}
+
+export function ScrollToTopButton({ scrollContainerRef }: ScrollToTopButtonProps) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+
+    const syncVisibility = () => {
+      const containerOffset = scrollContainer?.scrollTop ?? 0
+      const windowOffset = window.scrollY || document.documentElement.scrollTop || 0
+
+      setIsVisible(
+        containerOffset > VISIBILITY_THRESHOLD || windowOffset > VISIBILITY_THRESHOLD,
+      )
+    }
+
+    syncVisibility()
+    scrollContainer?.addEventListener('scroll', syncVisibility)
+    window.addEventListener('scroll', syncVisibility)
+
+    return () => {
+      scrollContainer?.removeEventListener('scroll', syncVisibility)
+      window.removeEventListener('scroll', syncVisibility)
+    }
+  }, [scrollContainerRef])
+
+  const handleScrollToTop = () => {
+    const behavior = getScrollBehavior()
+    const scrollContainer = scrollContainerRef.current
+
+    if (scrollContainer && scrollContainer.scrollTop > 0) {
+      scrollContainer.scrollTo({ top: 0, behavior })
+      return
+    }
+
+    window.scrollTo({ top: 0, behavior })
+  }
+
+  if (!isVisible) {
+    return null
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleScrollToTop}
+      aria-label="Scroll to top"
+      className="fixed bottom-5 right-5 z-20 inline-flex size-11 items-center justify-center rounded-full border border-sky-300/25 bg-slate-950/85 text-sky-50 shadow-lg shadow-slate-950/40 backdrop-blur-sm transition duration-200 hover:border-sky-200/40 hover:bg-slate-900 focus-visible:ring-2 focus-visible:ring-sky-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+    >
+      <ArrowUp aria-hidden="true" className="size-4" />
+    </button>
+  )
+}

--- a/test/portfolio-app.test.tsx
+++ b/test/portfolio-app.test.tsx
@@ -1,12 +1,13 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import App from '@/App'
 import { PROFILE } from '@/content/profile'
+import { RESUME_LINK } from '@/content/navigation'
 
 function getSourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -45,6 +46,9 @@ describe('portfolio app', () => {
   it('renders the one-page portfolio shell and removes starter content', () => {
     render(<App />)
     const sectionNav = screen.getByRole('navigation', { name: /portfolio sections/i })
+    const availabilityActions = screen.getByRole('group', {
+      name: /currently looking actions/i,
+    })
 
     expect(
       screen.getByRole('heading', { level: 1, name: /mark kenneth pelayo/i }),
@@ -66,10 +70,7 @@ describe('portfolio app', () => {
       'href',
       '#socials',
     )
-    expect(within(sectionNav).getByRole('link', { name: /resume/i })).toHaveAttribute(
-      'href',
-      'https://github.com/mkgp-dev/mkgp-dev/blob/main/storage/resume.pdf',
-    )
+    expect(within(sectionNav).queryByRole('link', { name: /resume/i })).not.toBeInTheDocument()
 
     expect(screen.getByRole('heading', { level: 2, name: /^projects$/i })).toBeInTheDocument()
     expect(
@@ -78,6 +79,21 @@ describe('portfolio app', () => {
     expect(screen.getByRole('heading', { level: 2, name: /journey/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 2, name: /^social$/i })).toBeInTheDocument()
     expect(screen.getByText(/currently looking/i)).toBeInTheDocument()
+    expect(screen.getByText(/view each certificate directly from this section/i)).toBeInTheDocument()
+
+    expect(within(availabilityActions).getByRole('link', { name: /resume/i })).toHaveAttribute(
+      'href',
+      RESUME_LINK.href,
+    )
+
+    const actionLinks = within(availabilityActions).getAllByRole('link')
+    expect(actionLinks.map((link) => link.getAttribute('href'))).toEqual([
+      RESUME_LINK.href,
+      PROFILE.availability.actions[0]?.href,
+      PROFILE.availability.actions[1]?.href,
+      PROFILE.availability.actions[2]?.href,
+    ])
+
     PROFILE.availability.actions.forEach((action) => {
       const matcher = new RegExp(action.label, 'i')
 
@@ -117,6 +133,36 @@ describe('portfolio app', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'start',
+    })
+  })
+
+  it('shows a scroll-to-top button after scrolling the content pane and scrolls it back to the top', async () => {
+    render(<App />)
+    const user = userEvent.setup()
+    const contentPane = screen.getByRole('main')
+    const scrollTo = vi.fn()
+
+    Object.defineProperty(contentPane, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    })
+    Object.defineProperty(contentPane, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    })
+
+    expect(screen.queryByRole('button', { name: /scroll to top/i })).not.toBeInTheDocument()
+
+    contentPane.scrollTop = 240
+    fireEvent.scroll(contentPane)
+
+    const button = screen.getByRole('button', { name: /scroll to top/i })
+    await user.click(button)
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
     })
   })
 


### PR DESCRIPTION
## Logs

### Added
- Added a floating scroll-to-top button that appears after the page content has been scrolled.
- Added test coverage for the relocated Resume action, certificate clarification copy, and scroll-to-top interaction.

### Changed
- Moved the `Resume` action out of the right-pane navigation and into the `Currently looking` action group.
- Updated the `Currently looking` action order to `Resume`, `Email`, `WhatsApp`, and `Viber`.
- Clarified the Certificates section description so visitors know they can open each certificate from that section.
- Updated README copy to reflect the new Resume placement and the added scroll-to-top behavior.